### PR TITLE
Refactor remote-state module configuration

### DIFF
--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -2,18 +2,14 @@ module "vpc" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  stack_config_local_path = "../../../stacks"
-  component               = "vpc"
-
-  context = module.this.context
+  component = "vpc"
+  context   = module.this.context
 }
 
 module "eks" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  stack_config_local_path = "../../../stacks"
-  component               = "eks"
-
-  context = module.this.context
+  component = "eks"
+  context   = module.this.context
 }


### PR DESCRIPTION
## what
* Drop `stack_config_local_path`

## why
* `stack_config_local_path` is deprecated 

## references
* https://github.com/orgs/cloudposse/discussions/102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing changes in this release.
- Chores
  - Streamlined remote state configuration by removing an obsolete local path setting, aligning with current infrastructure standards and simplifying maintenance. No impact expected to existing environments, workflows, or provisioning.
- Style
  - Normalized attribute ordering for improved readability. No functional changes, downtime, or actions required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->