### PR TITLE
Replace hardcoded security group with variable

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -4,6 +4,36 @@ github_repo: "cloudposse-terraform-components/aws-mq-broker"
 # Short description of this project
 description: |-
   This component is responsible for provisioning an AmazonMQ broker and the corresponding security group.
+
+
+  ### Migrate `v1` to `v2`
+
+  `EKS` component dependency removed. Instead of pulling security groups from EKS remote state, pass it as `var.allowed_security_groups`.
+  If you are using Atmos, read [atmos shared data](https://atmos.tools/core-concepts/share-data/) manual.
+
+  ```yaml
+  components:
+    terraform:
+      mq-broker:
+        vars:
+          enabled: true
+          apply_immediately: true
+          auto_minor_version_upgrade: true
+          deployment_mode: "ACTIVE_STANDBY_MULTI_AZ"
+          engine_type: "ActiveMQ"
+          engine_version: "5.15.14"
+          host_instance_type: "mq.t3.micro"
+          publicly_accessible: false
+          general_log_enabled: true
+          audit_log_enabled: true
+          encryption_enabled: true
+          use_aws_owned_key: true
+          allowed_security_groups: 
+            - '{{ (atmos.Component "eks" .stack).outputs.eks_cluster_managed_security_group_id }}'
+  ```
+
+
+  
 usage: |-
   **Stack Level**: Regional
 

--- a/src/main.tf
+++ b/src/main.tf
@@ -2,8 +2,6 @@ locals {
   eks_outputs = module.eks.outputs
   vpc_outputs = module.vpc.outputs
 
-  eks_cluster_managed_security_group_id = local.eks_outputs.eks_cluster_managed_security_group_id
-
   vpc_id             = local.vpc_outputs.vpc_id
   private_subnet_ids = local.vpc_outputs.private_subnet_ids
 

--- a/src/main.tf
+++ b/src/main.tf
@@ -17,7 +17,7 @@ module "mq_broker" {
 
   vpc_id                  = local.vpc_id
   subnet_ids              = local.subnet_ids
-  allowed_security_groups = [local.eks_cluster_managed_security_group_id]
+  allowed_security_groups = var.allowed_security_groups
 
   apply_immediately            = var.apply_immediately
   auto_minor_version_upgrade   = var.auto_minor_version_upgrade

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -5,11 +5,3 @@ module "vpc" {
   component = "vpc"
   context   = module.this.context
 }
-
-module "eks" {
-  source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
-
-  component = "eks"
-  context   = module.this.context
-}

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -188,3 +188,10 @@ variable "use_aws_owned_key" {
   default     = true
   description = "Boolean to enable an AWS owned Key Management Service (KMS) Customer Master Key (CMK) for Amazon MQ encryption that is not in your account"
 }
+
+variable "allowed_security_groups" {
+  type        = list(string)
+  default     = []
+  description = "List of Security Group IDs to be allowed to connect to the worker nodes"
+}
+

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -189,9 +189,3 @@ variable "use_aws_owned_key" {
   description = "Boolean to enable an AWS owned Key Management Service (KMS) Customer Master Key (CMK) for Amazon MQ encryption that is not in your account"
 }
 
-variable "allowed_security_groups" {
-  type        = list(string)
-  default     = []
-  description = "List of Security Group IDs to be allowed to connect to the mq broker"
-}
-

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -192,6 +192,6 @@ variable "use_aws_owned_key" {
 variable "allowed_security_groups" {
   type        = list(string)
   default     = []
-  description = "List of Security Group IDs to be allowed to connect to the worker nodes"
+  description = "List of Security Group IDs to be allowed to connect to the mq broker"
 }
 


### PR DESCRIPTION
## what
* Replace hardcoded security group with a variable

## why
* Get rid of `EKS` component dependency.

## references
* https://github.com/orgs/cloudposse/discussions/102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * MQ broker access can be configured with custom allowed security groups via a new variable, enabling environment-specific network control.
* Chores
  * Infrastructure updated to source allowed security groups from user input for easier customization.
  * Removed the public EKS remote state module declaration from the configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->