### PR TITLE
Remove unused cloudposse/template provider declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ No providers.
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_mq_broker"></a> [mq\_broker](#module\_mq\_broker) | cloudposse/mq-broker/aws | 3.6.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | cloudposse/stack-config/yaml//modules/remote-state | 2.0.0 |
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ components:
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.4 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | >= 2.2 |
 | <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 1.10.0 |
 
 ## Providers

--- a/src/README.md
+++ b/src/README.md
@@ -85,7 +85,7 @@ No providers.
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_mq_broker"></a> [mq\_broker](#module\_mq\_broker) | cloudposse/mq-broker/aws | 3.6.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | cloudposse/stack-config/yaml//modules/remote-state | 2.0.0 |
 
 ## Resources
 

--- a/src/README.md
+++ b/src/README.md
@@ -72,7 +72,6 @@ components:
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.4 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | >= 2.2 |
 | <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 1.10.0 |
 
 ## Providers

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -1,6 +1,6 @@
 module "vpc" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   component = "vpc"
   context   = module.this.context

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -6,10 +6,6 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 4.0, < 6.0.0"
     }
-    template = {
-      source  = "cloudposse/template"
-      version = ">= 2.2"
-    }
     local = {
       source  = "hashicorp/local"
       version = ">= 2.4"


### PR DESCRIPTION
## what

- Remove the `cloudposse/template` entry from `required_providers` in `src/versions.tf`
- Regenerate `README.md` / `src/README.md` via `atmos readme`

## why

- The `cloudposse/template` provider is declared in `required_providers` but is not referenced anywhere in `src/` — grepping for `template_` returns no matches. The declaration is a leftover from an earlier revision of the component
- The `cloudposse/template` provider itself is a fork of the long-deprecated `hashicorp/template` provider and is unmaintained (no modern `darwin_arm64` / `linux_arm64` builds in recent releases)
- Dropping the dead declaration eliminates an unnecessary deprecated transitive requirement for every consumer of this component

## references

- Template provider deprecation: https://github.com/hashicorp/terraform-provider-template