### PR TITLE
feat: expose `allow_all_egress` to tighten security group egress

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ components:
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.4 |
@@ -133,7 +133,7 @@ No providers.
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_mq_broker"></a> [mq\_broker](#module\_mq\_broker) | cloudposse/mq-broker/aws | 3.6.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
@@ -146,8 +146,9 @@ No resources.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br/>This is for some rare cases where resources want additional configuration of tags<br/>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
+| <a name="input_allow_all_egress"></a> [allow\_all\_egress](#input\_allow\_all\_egress) | If `true`, the created security group will allow egress on all ports and protocols to all IP addresses.<br/>If `false`, no egress rules will be created by this module; egress must be configured via other means<br/>(e.g. additional security group rules) or all outbound traffic will be denied. | `bool` | `true` | no |
 | <a name="input_allowed_cidr_blocks"></a> [allowed\_cidr\_blocks](#input\_allowed\_cidr\_blocks) | List of CIDR blocks that are allowed ingress to the broker's Security Group created in the module | `list(string)` | `[]` | no |
 | <a name="input_allowed_security_groups"></a> [allowed\_security\_groups](#input\_allowed\_security\_groups) | List of security groups to be allowed to connect to the broker instance | `list(string)` | `[]` | no |
 | <a name="input_apply_immediately"></a> [apply\_immediately](#input\_apply\_immediately) | Specifies whether any cluster modifications are applied immediately, or during the next maintenance window | `bool` | `false` | no |
@@ -201,7 +202,7 @@ No resources.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_admin_username"></a> [admin\_username](#output\_admin\_username) | AmazonMQ admin username |
 | <a name="output_application_username"></a> [application\_username](#output\_application\_username) | AmazonMQ application username |
 | <a name="output_broker_arn"></a> [broker\_arn](#output\_broker\_arn) | AmazonMQ broker ARN |

--- a/src/README.md
+++ b/src/README.md
@@ -68,7 +68,7 @@ components:
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0, < 6.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.4 |
@@ -81,7 +81,7 @@ No providers.
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_mq_broker"></a> [mq\_broker](#module\_mq\_broker) | cloudposse/mq-broker/aws | 3.6.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
@@ -94,8 +94,9 @@ No resources.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br/>This is for some rare cases where resources want additional configuration of tags<br/>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
+| <a name="input_allow_all_egress"></a> [allow\_all\_egress](#input\_allow\_all\_egress) | If `true`, the created security group will allow egress on all ports and protocols to all IP addresses.<br/>If `false`, no egress rules will be created by this module; egress must be configured via other means<br/>(e.g. additional security group rules) or all outbound traffic will be denied. | `bool` | `true` | no |
 | <a name="input_allowed_cidr_blocks"></a> [allowed\_cidr\_blocks](#input\_allowed\_cidr\_blocks) | List of CIDR blocks that are allowed ingress to the broker's Security Group created in the module | `list(string)` | `[]` | no |
 | <a name="input_allowed_security_groups"></a> [allowed\_security\_groups](#input\_allowed\_security\_groups) | List of security groups to be allowed to connect to the broker instance | `list(string)` | `[]` | no |
 | <a name="input_apply_immediately"></a> [apply\_immediately](#input\_apply\_immediately) | Specifies whether any cluster modifications are applied immediately, or during the next maintenance window | `bool` | `false` | no |
@@ -149,7 +150,7 @@ No resources.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_admin_username"></a> [admin\_username](#output\_admin\_username) | AmazonMQ admin username |
 | <a name="output_application_username"></a> [application\_username](#output\_application\_username) | AmazonMQ application username |
 | <a name="output_broker_arn"></a> [broker\_arn](#output\_broker\_arn) | AmazonMQ broker ARN |

--- a/src/main.tf
+++ b/src/main.tf
@@ -16,6 +16,7 @@ module "mq_broker" {
   vpc_id                  = local.vpc_id
   subnet_ids              = local.subnet_ids
   allowed_security_groups = var.allowed_security_groups
+  allow_all_egress        = var.allow_all_egress
 
   apply_immediately            = var.apply_immediately
   auto_minor_version_upgrade   = var.auto_minor_version_upgrade

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -111,6 +111,16 @@ variable "allowed_cidr_blocks" {
   description = "List of CIDR blocks that are allowed ingress to the broker's Security Group created in the module"
 }
 
+variable "allow_all_egress" {
+  type        = bool
+  default     = true
+  description = <<-EOT
+    If `true`, the created security group will allow egress on all ports and protocols to all IP addresses.
+    If `false`, no egress rules will be created by this module; egress must be configured via other means
+    (e.g. additional security group rules) or all outbound traffic will be denied.
+    EOT
+}
+
 variable "overwrite_ssm_parameter" {
   type        = bool
   default     = true


### PR DESCRIPTION
## what

- Expose new `allow_all_egress` input on the `mq-broker` component (default: `true`, preserves current behavior).
- Pass it through to the underlying `cloudposse/mq-broker/aws` module so consumers can opt into restricted outbound traffic on the broker's security group.
- Update `README.md` / `src/README.md` inputs tables with the new variable.

## why

- Tighten security group egress rules across our infrastructure. Mirrors the `allow_all_egress` pattern already exposed in the `elasticache-redis` component and matches the equivalent change being applied to `aurora-postgres` (`egress_enabled`, the upstream's name there).
- Defaulting to `true` keeps every existing stack unchanged — consumers opt in to restricted egress by setting `allow_all_egress: false`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated migration guidance from v1 to v2 with step-by-step instructions for removing EKS component dependency and adopting `allowed_security_groups` instead
  * Improved documentation table formatting and alignment

* **New Features**
  * Added `allow_all_egress` configuration option to control outbound traffic rule creation (enabled by default for backwards compatibility)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudposse-terraform-components/aws-mq-broker/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->